### PR TITLE
Make sure that `__dir__` returns new copies of `__all__`

### DIFF
--- a/lazy_loader/__init__.py
+++ b/lazy_loader/__init__.py
@@ -90,7 +90,7 @@ def attach(package_name, submodules=None, submod_attrs=None):
             raise AttributeError(f"No {package_name} attribute {name}")
 
     def __dir__():
-        return __all__
+        return list(__all__)
 
     if os.environ.get("EAGER_IMPORT", ""):
         for attr in set(attr_to_modules.keys()) | submodules:

--- a/lazy_loader/tests/test_lazy_loader.py
+++ b/lazy_loader/tests/test_lazy_loader.py
@@ -124,7 +124,7 @@ def test_lazy_attach_returns_copies():
 
     _all.append("modify_returned_all")
     assert _dir() == expected
-    assert _all == expected + ["modify_returned_all"]
+    assert _all == [*expected, "modify_returned_all"]
 
 
 def test_attach_same_module_and_attr_name():

--- a/lazy_loader/tests/test_lazy_loader.py
+++ b/lazy_loader/tests/test_lazy_loader.py
@@ -104,6 +104,29 @@ def test_lazy_attach():
             assert locls[k] == v
 
 
+def test_lazy_attach_returns_copies():
+    _get, _dir, _all = lazy.attach(
+        __name__, ["my_submodule", "another_submodule"], {"foo": ["some_attr"]}
+    )
+    assert _dir() is not _dir()
+    assert _dir() == _all
+    assert _dir() is not _all
+
+    expected = ["another_submodule", "my_submodule", "some_attr"]
+    assert _dir() == expected
+    assert _all == expected
+    assert _dir() is not _all
+
+    _dir().append("modify_returned_list")
+    assert _dir() == expected
+    assert _all == expected
+    assert _dir() is not _all
+
+    _all.append("modify_returned_all")
+    assert _dir() == expected
+    assert _all == expected + ["modify_returned_all"]
+
+
 def test_attach_same_module_and_attr_name():
     from lazy_loader.tests import fake_pkg
 


### PR DESCRIPTION
`__dir__()` should probably return new copies for each call so that the result will stay the same regardless of how the result of previous calls was modified. That seems to be the standard behavior for Python's default [`object.__dir__`](https://docs.python.org/3/library/functions.html#dir).

E.g.,
```python
import module_with_lazy_loading

assert dir(module_with_lazy_loading) is not dir(module_with_lazy_loading)

x = dir(module_with_lazy_loading)
x.pop()
assert x != dir(module_with_lazy_loading)
```
should all pass but currently they don't.
