### PR TITLE
Add `suppress_warning` parameter to the `load` function

### DIFF
--- a/lazy_loader/__init__.py
+++ b/lazy_loader/__init__.py
@@ -193,10 +193,10 @@ def load(fullname, *, require=None, error_on_import=False, suppress_warning=Fals
         if have_module and require is None:
             return module
 
-        if "." in fullname:
+        if not suppress_warning and "." in fullname:
             msg = (
                 "subpackages can technically be lazily loaded, but it causes the "
-                "package to be eagerly loaded even if it is already lazily loaded."
+                "package to be eagerly loaded even if it is already lazily loaded. "
                 "So, you probably shouldn't use subpackages with this lazy feature."
             )
             warnings.warn(msg, RuntimeWarning)

--- a/lazy_loader/__init__.py
+++ b/lazy_loader/__init__.py
@@ -118,7 +118,7 @@ class DelayedImportErrorModule(types.ModuleType):
             )
 
 
-def load(fullname, *, require=None, error_on_import=False):
+def load(fullname, *, require=None, error_on_import=False, suppress_warning=False):
     """Return a lazily imported proxy for a module.
 
     We often see the following pattern::
@@ -173,6 +173,10 @@ def load(fullname, *, require=None, error_on_import=False):
     error_on_import : bool
         Whether to postpone raising import errors until the module is accessed.
         If set to `True`, import errors are raised as soon as `load` is called.
+
+    suppress_warning : bool
+        Whether to prevent emitting a warning when loading subpackages.
+        If set to `True`, no warning will occur.
 
     Returns
     -------


### PR DESCRIPTION
I find this tedious to suppress using standard functionality.

My use case is a package `foo.bar` that consumers may import at any time that must lazily load `foo._bar`. This `foo._bar` module tests for the presence of a third party library but `foo.bar` can't just lazily load that library because it's functionality is not used all the time and we don't want to increase baseline memory for everyone.