### PR TITLE
test: Update test cases to get full coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,11 @@ ignore = [
   "SIM108",   # Use ternary operator
 ]
 
+[tool.ruff.lint.per-file-ignores]
+"tests/test_*.py" = [
+  "ARG001",  # Pytest fixtures are passed as arguments
+]
+
 [tool.ruff.format]
 docstring-code-format = true
 

--- a/src/lazy_loader/__init__.py
+++ b/src/lazy_loader/__init__.py
@@ -106,16 +106,13 @@ class DelayedImportErrorModule(types.ModuleType):
         super().__init__(*args, **kwargs)
 
     def __getattr__(self, x):
-        if x in ("__class__", "__file__", "__frame_data", "__message"):
-            super().__getattr__(x)
-        else:
-            fd = self.__frame_data
-            raise ModuleNotFoundError(
-                f"{self.__message}\n\n"
-                "This error is lazily reported, having originally occurred in\n"
-                f"  File {fd['filename']}, line {fd['lineno']}, in {fd['function']}\n\n"
-                f"----> {''.join(fd['code_context'] or '').strip()}"
-            )
+        fd = self.__frame_data
+        raise ModuleNotFoundError(
+            f"{self.__message}\n\n"
+            "This error is lazily reported, having originally occurred in\n"
+            f"  File {fd['filename']}, line {fd['lineno']}, in {fd['function']}\n\n"
+            f"----> {''.join(fd['code_context'] or '').strip()}"
+        )
 
 
 def load(fullname, *, require=None, error_on_import=False, suppress_warning=False):

--- a/tests/fake_pkg/__init__.py
+++ b/tests/fake_pkg/__init__.py
@@ -1,5 +1,5 @@
 import lazy_loader as lazy
 
 __getattr__, __lazy_dir__, __all__ = lazy.attach(
-    __name__, submod_attrs={"some_func": ["some_func"]}
+    __name__, submod_attrs={"some_func": ["some_func", "aux_func"]}
 )

--- a/tests/fake_pkg/__init__.pyi
+++ b/tests/fake_pkg/__init__.pyi
@@ -1,1 +1,1 @@
-from .some_func import some_func
+from .some_func import aux_func, some_func

--- a/tests/fake_pkg/some_func.py
+++ b/tests/fake_pkg/some_func.py
@@ -1,2 +1,6 @@
 def some_func():
     """Function with same name as submodule."""
+
+
+def aux_func():
+    """Auxiliary function."""

--- a/tests/test_lazy_loader.py
+++ b/tests/test_lazy_loader.py
@@ -123,6 +123,18 @@ def test_lazy_attach():
         if v is not None:
             assert locls[k] == v
 
+    # Exercise __getattr__, though it will just error
+    with pytest.raises(ImportError):
+        locls["__getattr__"]("mysubmodule")
+
+    # Attribute is supposed to be imported, error on submodule load
+    with pytest.raises(ImportError):
+        locls["__getattr__"]("some_var_or_func")
+
+    # Attribute is unknown, raise AttributeError
+    with pytest.raises(AttributeError):
+        locls["__getattr__"]("unknown_attr")
+
 
 def test_lazy_attach_returns_copies():
     _get, _dir, _all = lazy.attach(
@@ -221,6 +233,10 @@ def test_require_kwarg():
         # We can fail even after a successful import
         math = lazy.load("math", require="somepkg >= 2.0")
         assert isinstance(math, lazy.DelayedImportErrorModule)
+
+        # Eager failure
+        with pytest.raises(ModuleNotFoundError):
+            lazy.load("math", require="somepkg >= 2.0", error_on_import=True)
 
     # When a module can be loaded but the version can't be checked,
     # raise a ValueError

--- a/tests/test_lazy_loader.py
+++ b/tests/test_lazy_loader.py
@@ -37,18 +37,12 @@ def test_lazy_import_basics():
     # Now test that accessing attributes does what it should
     assert math.sin(math.pi) == pytest.approx(0, 1e-6)
     # poor-mans pytest.raises for testing errors on attribute access
-    try:
+    with pytest.raises(ModuleNotFoundError):
         anything_not_real.pi
-        raise AssertionError()  # Should not get here
-    except ModuleNotFoundError:
-        pass
     assert isinstance(anything_not_real, lazy.DelayedImportErrorModule)
     # see if it changes for second access
-    try:
+    with pytest.raises(ModuleNotFoundError):
         anything_not_real.pi
-        raise AssertionError()  # Should not get here
-    except ModuleNotFoundError:
-        pass
 
 
 def test_lazy_import_subpackages():
@@ -88,11 +82,8 @@ def test_lazy_import_nonbuiltins():
     if not isinstance(np, lazy.DelayedImportErrorModule):
         assert np.sin(np.pi) == pytest.approx(0, 1e-6)
     if isinstance(sp, lazy.DelayedImportErrorModule):
-        try:
+        with pytest.raises(ModuleNotFoundError):
             sp.pi
-            raise AssertionError()
-        except ModuleNotFoundError:
-            pass
 
 
 def test_lazy_attach():

--- a/tests/test_lazy_loader.py
+++ b/tests/test_lazy_loader.py
@@ -136,6 +136,14 @@ def test_lazy_attach():
         locls["__getattr__"]("unknown_attr")
 
 
+def test_lazy_attach_noattrs():
+    name = "mymod"
+    submods = ["mysubmodule", "anothersubmodule"]
+    _, _, all_ = lazy.attach(name, submods)
+
+    assert all_ == sorted(submods)
+
+
 def test_lazy_attach_returns_copies():
     _get, _dir, _all = lazy.attach(
         __name__, ["my_submodule", "another_submodule"], {"foo": ["some_attr"]}


### PR DESCRIPTION
I wanted to test the EAGER_IMPORT functionality, and figured we could cover these last few missing lines.

I did remove a guard in `DelayedImportErrorModule.__getattr__` that coverage showed was never being entered. That method does not need a `super()` call, since `__class__`, `__frame_data` and `__message` will all be retrieved without entering that function, and I don't think `__file__` needs to get a normal `AttributeError` instead of `ModuleNotFoundError`.